### PR TITLE
add feature: `add Mul<Gt> for Gt`, and `product`

### DIFF
--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -217,6 +217,7 @@ impl Fp2 {
         }
     }
 
+    /// Multiply this element by another element
     pub fn mul(&self, rhs: &Fp2) -> Self {
         // F_{p^2} x F_{p^2} multiplication implemented with operand scanning (schoolbook)
         // computes the result as:

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -996,6 +996,7 @@ impl G1Projective {
     impl_pippenger_sum_of_products!();
 }
 
+/// Group1 in it's compressed form
 #[derive(Clone, Copy)]
 pub struct G1Compressed([u8; 48]);
 
@@ -1039,6 +1040,7 @@ impl PartialEq for G1Compressed {
     }
 }
 
+/// Group1 in it's Uncompressed from
 #[derive(Clone, Copy)]
 pub struct G1Uncompressed([u8; 96]);
 

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -1277,6 +1277,7 @@ impl PartialEq for G2Compressed {
     }
 }
 
+/// Group2 in it's uncompressed form
 #[derive(Clone, Copy)]
 pub struct G2Uncompressed([u8; 192]);
 

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -438,7 +438,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a Gt {
     type Output = Gt;
 
     fn mul(self, other: &'b Scalar) -> Self::Output {
-        let mut acc = Gt::IDENTITY; 
+        let mut acc = Gt::IDENTITY;
 
         // This is a simple double-and-add implementation of group element
         // multiplication, moving from most significant to least


### PR DESCRIPTION
Hi Mike,

I've been using this fork of your as it's got some great functionality over the original.

I do need to be able to multiply `Gt` times `Gt`, so I thought I'd offer up this simple PR.

The `Fp12` `mul` is already there, just exposing it via some `impl`s