### PR TITLE
Fix for no_std builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ edition = "2021"
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-
 [dev-dependencies]
 ark-poly = "0.4.2"
 hex = "0.4"

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -83,7 +83,7 @@ impl From<u64> for Scalar {
     }
 }
 
-#[cfg(any(target_arch = "64", feature = "ark"))]
+#[cfg(feature = "ark")]
 impl From<u128> for Scalar {
     fn from(val: u128) -> Scalar {
         Self::from_u128(val)


### PR DESCRIPTION
I need to include this crate in a `no_std` build, by way of the [zkryptium](https://github.com/cybersecurity-LINKS/zkryptium/) crate.  But, this crate fails to build with `--no-default-features -F alloc -F groups`, because the `cdylib` target is requiring an allocator and panic_handler.

Cargo unfortunately does not seem to offer a way to override this attribute of a crate's Cargo.toml file.  Unfortunately, while it may appear that `crate_type` can be used as a conditional attribute within the source (https://doc.rust-lang.org/reference/linkage.html), this feature is actually deprecated https://github.com/rust-lang/rust/issues/91632.

I can only confirm that this tweak fixes my problem, but I am not sure if it breaks the 32-bit target you were addressing in f4a77325eed36946e1be41cb4c02f86c4b59d8c2.  With this change, I can `cargo build` with `wasm32-unknown-unknown` and `wasm32-wasip1`, but I'm not sure that's enough.  Can you please give it a try?  I'm happy to adjust this as needed.